### PR TITLE
Fixed favIcon path

### DIFF
--- a/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/partials/head.js
+++ b/src/main/archetype/ui.apps/src/main/content/jcr_root/apps/__appsFolderName__/components/structure/page/partials/head.js
@@ -21,6 +21,6 @@ use(function () {
 
     return {
         keywords: WCMUtils.getKeywords(currentPage, false),
-        favIcon: resourceResolver.getResource(currentDesign.getPath() + "/favicon.ico")
+        favIcon: resourceResolver.getResource(currentDesign.getPath() + "/favicon.ico").getPath()
     };
 });


### PR DESCRIPTION
This will allow the favIcon to be properly referenced in the head part of the page.

Signed-off-by: Robert Munteanu rmuntean@adobe.com
